### PR TITLE
Feature/My page

### DIFF
--- a/src/pages/mypages/alarm.js
+++ b/src/pages/mypages/alarm.js
@@ -1,0 +1,93 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const subscribeToggle = document.getElementById('subscribeToggle');
+    const subscriptionStatus = document.getElementById('subscriptionStatus');
+    const now = new Date();
+    
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    // 알림 설정 변경 시
+    subscribeToggle.addEventListener('change', async () => {
+        if (subscribeToggle.checked) {
+            // 알림 권한 요청
+            if (Notification.permission === 'default') {
+                const permission = await Notification.requestPermission();
+                if (permission !== 'granted') {
+                    alert('알림 권한이 필요합니다.');
+                    subscribeToggle.checked = false;
+                    return;
+                }
+            }
+
+            if (Notification.permission === 'granted') {
+                subscriptionStatus.textContent = '알림 구독중';
+                localStorage.setItem('notificationsEnabled', 'true');
+
+                // 공연 데이터 가져오기
+                fetch('../../data/concert_infos_date.json')
+                    .then(response => response.json())
+                    .then(data => {
+                        const upcomingConcerts = data.filter(concert => {
+                            const concertDate = new Date(concert.date);
+                            // 공연 날짜가 오늘 또는 내일이면 푸쉬 알림
+                            return concertDate >= today && concertDate < new Date(tomorrow.getTime() + 24 * 60 * 60 * 1000);
+                        });
+
+                        // 푸쉬 알림 보내기
+                        navigator.serviceWorker.ready.then(registration => {
+                            upcomingConcerts.forEach(concert => {
+                                registration.showNotification('다가오는 공연 알림', {
+                                    body: `${concert.title} 공연이 오늘 또는 내일입니다!`,
+                                    icon: concert.image,
+                                    vibrate: [200, 100, 200],
+                                    tag: `concert_${concert.idx}`, // 중복 방지 태그
+                                    data: {
+                                        url: `../classicConcertPages/${concert.link}` // 클릭 시 열릴 URL
+                                    }
+                                });
+                            });
+                        });
+                    })
+                    .catch(error => console.error('Error loading concert data:', error));
+            }
+        } else {
+            // 알림 구독 취소 처리
+            subscriptionStatus.textContent = '알림 구독';
+            localStorage.setItem('notificationsEnabled', 'false');
+        }
+    });
+
+    // 초기 상태 설정 (로컬 스토리지 기반)
+    const isSubscribed = localStorage.getItem('notificationsEnabled') === 'true';
+    subscribeToggle.checked = isSubscribed;
+    subscriptionStatus.textContent = isSubscribed ? '알림 구독중' : '알림 구독';
+
+    // 이미 구독 중이라면 공연 알림 체크
+    if (isSubscribed && Notification.permission === 'granted') {
+        fetch('../../data/concert_infos_date.json')
+            .then(response => response.json())
+            .then(data => {
+                const upcomingConcerts = data.filter(concert => {
+                    const concertDate = new Date(concert.date);
+                    // 공연 날짜가 오늘 또는 내일이면 푸쉬 알림
+                    return concertDate >= today && concertDate < new Date(tomorrow.getTime() + 24 * 60 * 60 * 1000);
+                });
+
+                navigator.serviceWorker.ready.then(registration => {
+                    upcomingConcerts.forEach(concert => {
+                        registration.showNotification('다가오는 공연 알림', {
+                            body: `${concert.title} 공연이 오늘 또는 내일입니다!`,
+                            icon: concert.image,
+                            vibrate: [200, 100, 200],
+                            tag: `concert_${concert.idx}`,
+                            data: {
+                                url: `../classicConcertPages/${concert.link}`
+                            }
+                        });
+                    });
+                });
+            })
+            .catch(error => console.error('Error loading concert data:', error));
+    }
+});

--- a/src/pages/mypages/alarm.js
+++ b/src/pages/mypages/alarm.js
@@ -7,6 +7,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const tomorrow = new Date(today);
     tomorrow.setDate(today.getDate() + 1);
 
+    // 로컬 스토리지에서 하트 상태 불러오기
+    const heartState = Object.keys(localStorage).reduce((acc, key) => {
+        if (key.startsWith('heartLiked_')) {
+            acc[key.replace('heartLiked_', '')] = localStorage.getItem(key) === 'true';
+        }
+        return acc;
+    }, {});
+
     // 알림 설정 변경 시
     subscribeToggle.addEventListener('change', async () => {
         if (subscribeToggle.checked) {
@@ -37,7 +45,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const upcomingConcerts = data.filter(concert => {
                             const concertDate = new Date(concert.date);
                             // 공연 날짜가 오늘 또는 내일이면 푸쉬 알림
-                            return concertDate >= today && concertDate < new Date(tomorrow.getTime() + 24 * 60 * 60 * 1000);
+                            const heartKey = `${concert.idx}`;
+                            return concertDate >= today && concertDate < new Date(tomorrow.getTime() + 24 * 60 * 60 * 1000) && heartState[heartKey];
                         });
 
                         // 푸쉬 알림 보내기
@@ -77,7 +86,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const upcomingConcerts = data.filter(concert => {
                     const concertDate = new Date(concert.date);
                     // 공연 날짜가 오늘 또는 내일이면 푸쉬 알림
-                    return concertDate >= today && concertDate < new Date(tomorrow.getTime() + 24 * 60 * 60 * 1000);
+                    const heartKey = `${concert.idx}`;
+                    return concertDate >= today && concertDate < new Date(tomorrow.getTime() + 24 * 60 * 60 * 1000) && heartState[heartKey];
                 });
 
                 navigator.serviceWorker.ready.then(registration => {

--- a/src/pages/mypages/alarm.js
+++ b/src/pages/mypages/alarm.js
@@ -10,6 +10,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // 알림 설정 변경 시
     subscribeToggle.addEventListener('change', async () => {
         if (subscribeToggle.checked) {
+            // 알림 권한이 "차단" 상태라면
+            if (Notification.permission === 'denied') {
+                alert('알림 권한이 차단되어 있습니다. 알림을 받으려면 브라우저 설정에서 알림 권한을 허용해주세요.');
+                subscribeToggle.checked = false; // 다시 체크 해제
+                return;
+            }
             // 알림 권한 요청
             if (Notification.permission === 'default') {
                 const permission = await Notification.requestPermission();

--- a/src/pages/mypages/myPage.html
+++ b/src/pages/mypages/myPage.html
@@ -41,6 +41,15 @@
                 <div class="title-rectangle"></div>
                 <h1 class="title">공연 정보 소개</h1>
             </div>
+
+            <!-- 푸쉬알림 설정 버튼 -->
+            <div class="subscription-container">
+                <label class="toggle-switch">
+                    <input type="checkbox" id="subscribeToggle">
+                    <span class="slider"></span>
+                </label>
+                <span id="subscriptionStatus">구독하기</span>
+            </div>
     
             <!-- 탭 버튼 -->
             <div class="tabs">
@@ -67,6 +76,7 @@
 
 
     <script src="mypages_detail.js"></script>
+    <script src="alarm.js"></script>
 
 </body>
 </html>

--- a/src/pages/mypages/style.css
+++ b/src/pages/mypages/style.css
@@ -269,3 +269,59 @@ button {
 .heart-icon:active {
     transform: scale(1.2); /* 클릭 시 확대 */
 }
+
+.subscription-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 15px;
+    margin-bottom: 10px;
+}
+
+/* 토글 스위치 */
+.toggle-switch {
+    position: relative;
+    width: 50px;
+    height: 25px;
+    display: inline-block;
+}
+
+/* 숨겨진 체크박스 */
+.toggle-switch input {
+    display: none;
+}
+
+/* 스위치 배경 */
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: 0.4s;
+    border-radius: 25px;
+}
+
+/* 스위치 동그라미 */
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 4px;
+    bottom: 3.5px;
+    background-color: white;
+    transition: 0.4s;
+    border-radius: 50%;
+}
+
+/* 토글 활성화 시 */
+input:checked + .slider {
+    background-color: orange;
+}
+
+input:checked + .slider:before {
+    transform: translateX(24px);
+}

--- a/src/pages/mypages/sw.js
+++ b/src/pages/mypages/sw.js
@@ -1,0 +1,9 @@
+self.addEventListener('notificationclick', event => {
+    event.notification.close(); // 알림 닫기
+    const url = event.notification.data?.url;
+    if (url) {
+        event.waitUntil(
+            clients.openWindow(url) // 지정된 URL로 이동
+        );
+    }
+});


### PR DESCRIPTION
## title
> 예정 공연 푸쉬 알림 기능 추가

## 개요
> 예정되어 있는 공연이 하루 전 혹은 당일이라면 푸쉬 알림을 통해 일정을 알려주는 기능을 구현함.

## 연관된 이슈
> #55 

## 변경사항 및 이유
- [ ] 푸쉬 알림을 설정하는 버튼 추가 및 디자인
- [ ] 푸쉬 알림 권한 허용 여부 판단 후 허용되지 않았다면 경고창 띄우기
- [ ] 마이페이지에 하트로 누른 예정되어 있는 공연이 하루 전 혹은 당일이라면 푸쉬 알림

## 리뷰 요구사항(선택)
